### PR TITLE
fix: created CloneCircuit function

### DIFF
--- a/extractor/lean_export.go
+++ b/extractor/lean_export.go
@@ -151,7 +151,15 @@ func GetSchema(circuit any) (*schema.Schema, error) {
 	return schema.New(circuit, tVariable)
 }
 
+func CloneCircuit(circuit abstractor.Circuit) abstractor.Circuit {
+	v := reflect.ValueOf(circuit).Elem()
+	vp2 := reflect.New(v.Type())
+	vp2.Elem().Set(v)
+	return vp2.Interface().(abstractor.Circuit)
+}
+
 func CircuitToLean(circuit abstractor.Circuit, field ecc.ID) (string, error) {
+	circuit = CloneCircuit(circuit)
 	schema, err := GetSchema(circuit)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
This PR fixes the pointer error caused if the circuit passed to `CircuitToLean` is used in other operations.

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->
I have created a `CloneCircuit` function which performs a deep copy of the circuit object.

# Checklist

- [x] Documentation has been updated if necessary.
