### PR TITLE
feat: added abstractor.CallGadget

### DIFF
--- a/abstractor/abstractor.go
+++ b/abstractor/abstractor.go
@@ -26,3 +26,7 @@ type Circuit interface {
 func Concretize(api frontend.API, circuit Circuit) error {
 	return circuit.AbsDefine(&Concretizer{api})
 }
+
+func CallGadget(api frontend.API, circuit GadgetDefinition) []frontend.Variable {
+	return circuit.DefineGadget(&Concretizer{api})
+}


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
This PR adds a concretizer for Gadgets so they can be plugged in existing Gnark circuits

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->
Before
```go
x3 := Power(api, circuit.X, 3)
```

After
```go
x3 := abstractor.CallGadget(api, PowerGadget{circuit.X, 3})[0]
```

# Checklist

- [x] Documentation has been updated if necessary.
