### PR TITLE
fix: Concretizer.Call loop

### DIFF
--- a/abstractor/concretizer.go
+++ b/abstractor/concretizer.go
@@ -123,7 +123,7 @@ func (c *Concretizer) DefineGadget(gadget GadgetDefinition) Gadget {
 }
 
 func (c *Concretizer) Call(gadget GadgetDefinition) []frontend.Variable {
-	return c.Call(gadget)
+	return c.DefineGadget(gadget).Call(gadget)
 }
 
 var _ API = &(Concretizer{})


### PR DESCRIPTION
# Summary

`Concretizer.Call` calls `DefineGadget` first

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->

# Checklist

- [x] Documentation has been updated if necessary.
