### PR TITLE
fix: `ToBinary` and nested Slices

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 
 	"github.com/reilabs/gnark-lean-extractor/abstractor"
 
@@ -353,6 +354,13 @@ func getGadgetByName(gadgets []ExGadget, name string) abstractor.Gadget {
 	return nil
 }
 
+func getSize(elem ExArgType) []string {
+	if elem.Type == nil {
+		return []string{fmt.Sprintf("%d", elem.Size)}
+	}
+	return append(getSize(*elem.Type), fmt.Sprintf("%d", elem.Size))
+}
+
 func (ce *CodeExtractor) DefineGadget(gadget abstractor.GadgetDefinition) abstractor.Gadget {
 	if reflect.ValueOf(gadget).Kind() != reflect.Ptr {
 		panic("DefineGadget only takes pointers to the gadget")
@@ -372,7 +380,8 @@ func (ce *CodeExtractor) DefineGadget(gadget abstractor.GadgetDefinition) abstra
 	suffix := ""
 	for _, a := range args {
 		if a.Kind == reflect.Array || a.Kind == reflect.Slice {
-			suffix += fmt.Sprintf("_%d", a.Type.Size)
+			suffix += "_"
+			suffix += strings.Join(getSize(a.Type), "_")
 		}
 	}
 	name := fmt.Sprintf("%s%s", reflect.TypeOf(gadget).Elem().Name(), suffix)

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -253,8 +253,13 @@ func (ce *CodeExtractor) ToBinary(i1 frontend.Variable, n ...int) []frontend.Var
 			panic("Number of bits in ToBinary must be > 0")
 		}
 	}
+
 	gate := ce.AddApp(OpToBinary, i1, nbBits)
-	return []frontend.Variable{gate}
+	outs := make([]frontend.Variable, nbBits)
+	for i := range outs {
+		outs[i] = Proj{gate, i}
+	}
+	return outs
 }
 
 func (ce *CodeExtractor) FromBinary(b ...frontend.Variable) frontend.Variable {

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -124,13 +124,14 @@ func (g *ExGadget) Call(gadget abstractor.GadgetDefinition) []frontend.Variable 
 	for i := 0; i < rt.NumField(); i++ {
 		fld := rt.Field(i)
 		v := rv.FieldByName(fld.Name)
-		if v.Kind() == reflect.Slice {
+		switch v.Kind() {
+		case reflect.Slice:
 			args = append(args, v.Interface().([]frontend.Variable))
-		} else if v.Kind() == reflect.Array {
+		case reflect.Array:
 			// I can't convert from array to slice using Reflect because
 			// the field is unaddressable.
 			args = append(args, ArrayToSlice(v))
-		} else {
+		case reflect.Interface:
 			args = append(args, v.Elem().Interface().(frontend.Variable))
 		}
 	}

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -190,23 +190,26 @@ func TestMerkleRecover(t *testing.T) {
 type MyWidget struct {
 	Test_1 frontend.Variable
 	Test_2 frontend.Variable
+	Num int
 }
 
 func (gadget MyWidget) DefineGadget(api abstractor.API) []frontend.Variable {
 	sum := api.Add(gadget.Test_1, gadget.Test_2)
 	mul := api.Mul(gadget.Test_1, gadget.Test_2)
 	r := api.Div(sum, mul)
+	api.AssertIsBoolean(gadget.Num)
 	return []frontend.Variable{r}
 }
 
 type MySecondWidget struct {
 	Test_1 frontend.Variable
 	Test_2 frontend.Variable
+	Num int
 }
 
 func (gadget MySecondWidget) DefineGadget(api abstractor.API) []frontend.Variable {
 	mul := api.Mul(gadget.Test_1, gadget.Test_2)
-	snd := api.Call(MyWidget{gadget.Test_1, gadget.Test_2})[0]
+	snd := api.Call(MyWidget{gadget.Test_1, gadget.Test_2, gadget.Num})[0]
 	r := api.Mul(mul, snd)
 	return []frontend.Variable{r}
 }
@@ -214,13 +217,13 @@ func (gadget MySecondWidget) DefineGadget(api abstractor.API) []frontend.Variabl
 type TwoGadgets struct {
 	In_1 frontend.Variable
 	In_2 frontend.Variable
+	Num int
 }
 
 func (circuit *TwoGadgets) AbsDefine(api abstractor.API) error {
 	sum := api.Add(circuit.In_1, circuit.In_2)
 	prod := api.Mul(circuit.In_1, circuit.In_2)
-	api.Call(MySecondWidget{sum, prod})
-
+	api.Call(MySecondWidget{sum, prod, circuit.Num})
 	return nil
 }
 
@@ -229,7 +232,7 @@ func (circuit TwoGadgets) Define(api frontend.API) error {
 }
 
 func TestTwoGadgets(t *testing.T) {
-	assignment := TwoGadgets{}
+	assignment := TwoGadgets{Num: 11}
 	out, err := CircuitToLean(&assignment, ecc.BN254)
 	if err != nil {
 		log.Fatal(err)

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -27,8 +27,8 @@ func (gadget VectorGadget) DefineGadget(api abstractor.API) []frontend.Variable 
 }
 
 type ToBinaryCircuit struct {
-	In  frontend.Variable `gnark:",public"`
-	Out frontend.Variable `gnark:",public"`
+	In     frontend.Variable     `gnark:",public"`
+	Out    frontend.Variable     `gnark:",public"`
 	Double [][]frontend.Variable `gnark:",public"`
 }
 

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -27,8 +27,8 @@ func (gadget VectorGadget) DefineGadget(api abstractor.API) []frontend.Variable 
 }
 
 type ToBinaryCircuit struct {
-	In  frontend.Variable   `gnark:",public"`
-	Out frontend.Variable   `gnark:",public"`
+	In  frontend.Variable `gnark:",public"`
+	Out frontend.Variable `gnark:",public"`
 }
 
 func (circuit *ToBinaryCircuit) AbsDefine(api abstractor.API) error {

--- a/extractor/extractor_test.go
+++ b/extractor/extractor_test.go
@@ -190,7 +190,7 @@ func TestMerkleRecover(t *testing.T) {
 type MyWidget struct {
 	Test_1 frontend.Variable
 	Test_2 frontend.Variable
-	Num int
+	Num    int
 }
 
 func (gadget MyWidget) DefineGadget(api abstractor.API) []frontend.Variable {
@@ -204,7 +204,7 @@ func (gadget MyWidget) DefineGadget(api abstractor.API) []frontend.Variable {
 type MySecondWidget struct {
 	Test_1 frontend.Variable
 	Test_2 frontend.Variable
-	Num int
+	Num    int
 }
 
 func (gadget MySecondWidget) DefineGadget(api abstractor.API) []frontend.Variable {
@@ -217,7 +217,7 @@ func (gadget MySecondWidget) DefineGadget(api abstractor.API) []frontend.Variabl
 type TwoGadgets struct {
 	In_1 frontend.Variable
 	In_2 frontend.Variable
-	Num int
+	Num  int
 }
 
 func (circuit *TwoGadgets) AbsDefine(api abstractor.API) error {


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
This code change allows direct indexing of elements returned by the ToBinary operation.

This branch also fixes the initialisation of nested arrays when used in Gadget inputs: the old code would assign a slice of type `[]frontend.Variable` to a slice of type `[][]frontend.Variable`. The new code recursively walks through the nested arrays for correct assignments.

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->

# Checklist

- [x] Documentation has been updated if necessary.
